### PR TITLE
Update docker-entrypoint.sh - For changes in CS 4.10

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,7 @@ IPADDRESS="$(ip address | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cu
 
 cd /opt/cobaltstrike
 token=`curl -s https://download.cobaltstrike.com/download -d "dlkey=${COBALTSTRIKE_KEY}" | grep 'href="/downloads/' | cut -d '/' -f3`
-curl -s https://download.cobaltstrike.com/downloads/${token}/latest46/cobaltstrike-dist.tgz -o /tmp/cobaltstrike.tgz
+curl -s https://download.cobaltstrike.com/downloads/${token}/latest410/cobaltstrike-dist-linux.tgz -o /tmp/cobaltstrike.tgz
 tar zxf /tmp/cobaltstrike.tgz -C /opt
 echo ${COBALTSTRIKE_KEY} | /opt/cobaltstrike/update
 /opt/cobaltstrike/teamserver $IPADDRESS ${COBALTSTRIKE_PASS} /opt/cobaltstrike/profiles/${COBALTSTRIKE_PROFILE}.profile ${COBALTSTRIKE_EXP}


### PR DESCRIPTION
To download the latest CS version a change had to be made for the curl command utilized to fetch the files. This is a slight modification to ensure the container is able to restart properly.